### PR TITLE
adiciona cancelamento de agendamento

### DIFF
--- a/src/Providers/FleuryScheduledTelemedicineProvider.php
+++ b/src/Providers/FleuryScheduledTelemedicineProvider.php
@@ -262,6 +262,33 @@ class FleuryScheduledTelemedicineProvider implements ScheduledTelemedicineProvid
         return $response->json('attendance_link');
     }
 
+
+    public function cancelAppointment(string $appointmentId): array
+    {
+        $attempts = 0;
+        $maxAttempts = 3;
+
+        while ($attempts < $maxAttempts) {
+            try {
+                $this->ensureIsAuthenticated();
+                $response = $this->newRequest()
+                    ->patch("integration/cuidado-digital/v1/consultas/{$appointmentId}/cancel")
+                    ->onError(fn (Response $response) => $this->errorHandler->handleErrors($response));
+
+                return ['success' => true, 'message' => 'Agendamento cancelado com sucesso.'];
+            } catch (\Throwable $e) {
+                $attempts++;
+                if ($e->getCode() === 504 && $attempts < $maxAttempts) {
+                    sleep(5);; // Aguarde um pouco antes de tentar novamente.
+                    continue;
+                }
+                return ['success' => false, 'message' => 'Falha temporária, tente novamente mais tarde.'];
+            }
+        }
+
+        return ['success' => false, 'message' => 'O cancelamento falhou após várias tentativas.'];
+    }
+
     private function newRequest(bool $withToken = true): PendingRequest
     {
         $request = Http::baseUrl($this->baseUrl)->asJson();

--- a/src/Testing/FakeScheduledTelemedicineProvider.php
+++ b/src/Testing/FakeScheduledTelemedicineProvider.php
@@ -33,6 +33,9 @@ class FakeScheduledTelemedicineProvider implements ScheduledTelemedicineProvider
     /** @var array<string, array{PatientData, Appointment}> */
     private array $appointments = [];
 
+    private $nextResponse = ['success' => true, 'message' => 'Agendamento cancelado com sucesso.'];
+
+
     public function __construct()
     {
         $this->faker = Factory::create(config('app.faker_locale', Factory::DEFAULT_LOCALE));
@@ -44,6 +47,28 @@ class FakeScheduledTelemedicineProvider implements ScheduledTelemedicineProvider
 
         return $this;
     }
+
+    public function authenticate(): void
+    {
+        // Do nothing
+    }
+
+    public function setNextResponse(array $response) {
+        $this->nextResponse = $response;
+    }
+
+    public function cancelAppointment(string $appointmentId): array {
+        if ($this->shouldFail($appointmentId)) {
+            return ['success' => false, 'message' => 'Falha ao cancelar.'];
+        }
+        return $this->nextResponse;
+    }
+
+    private function shouldFail($appointmentId): bool {
+        // Simular falhas baseadas no ID do agendamento, por exemplo.
+        return in_array($appointmentId, ['failId1', 'failId2']);
+    }
+
 
     public function getDoctors(?string $specialty = null, ?string $name = null): DoctorCollection
     {


### PR DESCRIPTION
**Título**: Implementação do Método de Cancelamento de Agendamentos na API da Fleury

**Objetivo**:
Este MR introduz um novo método `cancelAppointment` na biblioteca de integração com a API da Fleury, permitindo o cancelamento de agendamentos de telemedicina ;

**Detalhes da Implementação**:
1. **Método `cancelAppointment`**:
   - Adicionado à classe `FleuryScheduledTelemedicineProvider`.
   - Gerencia o processo de cancelamento de um agendamento através do ID fornecido, utilizando a rota PATCH no endpoint específico da API da Fleury.
   - Inclui lógica de tentativas múltiplas para lidar com possíveis instabilidades temporárias da API (ex.: falhas temporárias de rede).

2. **Gestão de Erros**:
   - Tratamento de erros com tentativas de reenvio, usando um máximo de três tentativas antes de considerar o cancelamento como falho.
   - Retorno de mensagens claras sobre o sucesso ou falha do cancelamento, proporcionando feedback adequado para ações subsequentes no sistema.

**Justificativa**:
A funcionalidade de cancelamento é essencial para permitir operações dinâmicas e flexíveis dentro do fluxo de trabalho de agendamentos de telemedicina, especialmente para lidar com mudanças e imprevistos que requerem cancelamentos rápidos e eficientes.

